### PR TITLE
Remove useless call to unregisterHook()

### DIFF
--- a/products.php
+++ b/products.php
@@ -63,7 +63,6 @@ class Products extends Module
     {
         return parent::uninstall()
             && AlternativeDescription::removeToProductTable()
-            && $this->unregisterHook($this->productHooks)
         ;
     }
 


### PR DESCRIPTION
This is already handle by PrestaShop

https://github.com/PrestaShop/PrestaShop/blob/4c4f83de191fa30b364e6242da5005b4503a780c/classes/module/Module.php#L707